### PR TITLE
Fix links, Add docs about using the dev docker image.

### DIFF
--- a/installation/6.docker.md
+++ b/installation/6.docker.md
@@ -3,14 +3,14 @@ In this wiki page we explain how to deploy MAD using docker.
 
 
 If you do not have a clue about docker, you maybe want to check out:
- - https://www.docker.com/why-docker
- - https://www.docker.com/resources/what-container
+ - [https://www.docker.com/why-docker]()
+ - [https://www.docker.com/resources/what-container]()
 
 ## Get Docker
 First of all, you have to install Docker CE and docker-compose on your system.
 
-- Docker CE: just execute that script https://get.docker.com/ or read through https://docs.docker.com/install/ 
-- Docker-compose: https://docs.docker.com/compose/install/
+- Docker CE: just execute this script [https://get.docker.com/]() - or read through [https://docs.docker.com/install/]() 
+- Docker-compose: [https://docs.docker.com/compose/install/]()
 
 These sites are well documented and if you follow the install instructions, you are good to go.
 
@@ -106,8 +106,9 @@ services:
 
 The docker-compose file defines a set of services.
 #### 1.2.1 The `mad` service
-The `mad` service is a docker-container based on the image [mapadroid/map-a-droid](https://hub.docker.com/r/mapadroid/map-a-droid) , which is automatically built by dockerhub whenever a push to `master` happens, using the [Dockerfile](https://github.com/Map-A-Droid/MAD/blob/master/Dockerfile).
-If you want to use the `dev` branch, you can pull the image from `breedocker/mad:dev` or build it yourself.
+The `mad` service is a docker-container based on the image [mapadroid/map-a-droid](https://hub.docker.com/r/mapadroid/map-a-droid) , which is automatically built by dockerhub whenever a push to the `master` happens, using this [Dockerfile](https://github.com/Map-A-Droid/MAD/blob/master/Dockerfile).
+
+- Note: If you want to use the `dev` branch, you have to pull the image from [mapadroid/mad_dev_branch](https://hub.docker.com/r/mapadroid/mad_dev_branch). Make sure your `mappings.json` and `config.ini` work on the `dev` branch.
 
 In the docker-image, the whole MAD repository is located in `/usr/src/app`.
 
@@ -199,7 +200,7 @@ I don't want to write all the steps we currently do^^
 - **Router:** we recommend [Traefik](https://docs.traefik.io/), which is really easy to use and also a docker-container ;)
 To secure the docker-socket (which traefik has access to) we recommend the [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) by Tecnativa.
 - **Automatic updates:** [Watchtower](https://github.com/containrrr/watchtower) is a useful tool which will update your docker-services once there are newer images available.
-- **Pokealarm, PMSF:** check out our docker-compose used https://github.com/Breee/pogo-map-package
+- **Pokealarm, PMSF:** check out our docker-compose used here: [https://github.com/Breee/pogo-map-package]()
 
 
 ## Something is missing?


### PR DESCRIPTION
1. Grennith just enabled autobuilds for dev: https://hub.docker.com/r/mapadroid/mad_dev_branch
Added information to the docs. 
2. fixed some links