### PR TITLE
docker, add info to create mappings.json when starting from scratch

### DIFF
--- a/installation/6.docker.md
+++ b/installation/6.docker.md
@@ -3,14 +3,14 @@ In this wiki page we explain how to deploy MAD using docker.
 
 
 If you do not have a clue about docker, you maybe want to check out:
- - [https://www.docker.com/why-docker]()
- - [https://www.docker.com/resources/what-container]()
+ - [https://www.docker.com/why-docker](https://www.docker.com/why-docker)
+ - [https://www.docker.com/resources/what-container](https://www.docker.com/resources/what-container)
 
 ## Get Docker
 First of all, you have to install Docker CE and docker-compose on your system.
 
-- Docker CE: just execute this script [https://get.docker.com/]() - or read through [https://docs.docker.com/install/]() 
-- Docker-compose: [https://docs.docker.com/compose/install/]()
+- Docker CE: just execute this script [https://get.docker.com/](https://get.docker.com/) - or read through [https://docs.docker.com/install/](https://docs.docker.com/install/) 
+- Docker-compose: [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
 
 These sites are well documented and if you follow the install instructions, you are good to go.
 
@@ -30,10 +30,11 @@ touch docker-compose.yml && \
 mkdir docker-entrypoint-initdb && \
 wget -O docker-entrypoint-initdb/rocketmap.sql https://raw.githubusercontent.com/Map-A-Droid/MAD/dev/scripts/SQL/rocketmap.sql && \
 cd mad/configs/ && \
+touch mappings.json && \
 wget -O config.ini https://raw.githubusercontent.com/Map-A-Droid/MAD/master/configs/config.ini.example && \
-wget -O mappings.json https://raw.githubusercontent.com/Map-A-Droid/MAD/master/configs/mappings_example.json  && \
 mkdir geofences && cd ../../
 ```
+
 This will: 
 1. Create a directory `MAD-docker`. 
 2. Create a file `docker-compose.yml`.
@@ -57,6 +58,43 @@ Your directory should now look like this:
       |-- mappings.json
       |-- geofences/
  ```
+
+If you start from scratch, add the following content to `mad/configs/mappings.json`:
+``` 
+{
+    "areas": {
+        "entries": {},
+        "index": 0
+    },
+    "auth": {
+        "entries": {},
+        "index": 0
+    },
+    "devices": {
+        "entries": {},
+        "index": 0
+    },
+    "devicesettings": {
+        "entries": {},
+        "index": 0
+    },
+    "migrated": true,
+    "monivlist": {
+        "entries": {},
+        "index": 0
+    },
+    "walker": {
+        "entries": {},
+        "index": 0
+    },
+    "walkerarea": {
+        "entries": {},
+        "index": 0
+    }
+}
+```
+If you have an existing `mappings.json`, because you used MAD before, then just copy it over.
+
  
 ### 1.2 Writing the docker-compose file.
 We use `docker-compose` to deploy and manage our services.


### PR DESCRIPTION
MAD no longer uses mapping.json.example,
Someone that starts from scratch now has to create an empty one with the content: 

```
{
    "areas": {
        "entries": {},
        "index": 0
    },
    "auth": {
        "entries": {},
        "index": 0
    },
    "devices": {
        "entries": {},
        "index": 0
    },
    "devicesettings": {
        "entries": {},
        "index": 0
    },
    "migrated": true,
    "monivlist": {
        "entries": {},
        "index": 0
    },
    "walker": {
        "entries": {},
        "index": 0
    },
    "walkerarea": {
        "entries": {},
        "index": 0
    }
}
```


Tested it locally, works for me.
People which migrate to docker with existing mappings.json, should not run into trouble.