### PR TITLE
Allow makefile variables use command line/env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = python3 -msphinx
-SOURCEDIR     = .
-BUILDDIR      = _build
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= python3 -msphinx
+SOURCEDIR     ?= .
+BUILDDIR      ?= _build
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION
Fixes https://github.com/Map-A-Droid/MAD-docs/issues/53

As per https://www.gnu.org/software/make/manual/make.html#Flavors

>There is another assignment operator for variables, ‘?=’. This is called a conditional variable assignment operator, because it only has an effect if the variable is not yet defined.