### PR TITLE
Fix broken link to Sphinx in footer

### DIFF
--- a/_themes/guzzle_sphinx_mad_theme/layout.html
+++ b/_themes/guzzle_sphinx_mad_theme/layout.html
@@ -149,7 +149,7 @@
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 {%- block footer_wrapper %}
   <div class="footer">
-    &copy; Copyright {{ copyright }}. Created using <a href="http://sphinx.pocoo.org/">Sphinx</a>.
+    &copy; Copyright {{ copyright }}. Created using <a href="https://www.sphinx-doc.org/">Sphinx</a>.
   </div>
 {%- endblock %}
 {%- endblock %}


### PR DESCRIPTION
http://sphinx.pocoo.org/ gives a 400.

As per http://www.pocoo.org/

> sphinx-doc.org is the new home of the Sphinx documentation tool.