### PR TITLE
Fix buildthedocs, new format

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,4 +26,4 @@ sphinx:
 formats: all
 python:
     install:
-    - requirements: docs/requirements.txt
+    - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+python:
+    install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,1 +1,0 @@
-requirements_file: requirements.txt


### PR DESCRIPTION
Seems to be working in my test repository, so I hope it will build here too and @muckelba didn't do any magic in webpanel :D 

Btw. I love the building process on readthedocs - if you add the v2 `.yaml` file without deleting the v1 `.yml` it will tell you that it can't find file `.yaml` file and build is stopped >.>