### PR TITLE
Added missing code blocks in Manual Installation

### DIFF
--- a/installation/manual.rst
+++ b/installation/manual.rst
@@ -106,7 +106,7 @@ And create a new virtual environment called :code:`mad_env` in your home directo
 
 Whenever you see :code:`python3` or :code:`pip3` in the documentation, use :code:`~/mad_env/bin/python3` and :code:`~/mad_env/bin/pip3` instead. And, of course, use a different environment location for different python tools.
 
-You can activate the virtual environment via :code:`source ~/mad_env/bin/activate`. This makes sure you can simply call `python3` or `pip3` wherever you are and it will perform all commands with the Python version and the dependencies form your virtualenvironment. Have a look at `this <https://docs.python.org/3/tutorial/venv.html>`_ or `this <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/>`_ link for more information.
+You can activate the virtual environment via :code:`source ~/mad_env/bin/activate`. This makes sure you can simply call :code:`python3` or :code:`pip3` wherever you are and it will perform all commands with the Python version and the dependencies form your virtualenvironment. Have a look at `this <https://docs.python.org/3/tutorial/venv.html>`_ or `this <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/>`_ link for more information.
 
 .. _sec_manual_mad:
 

--- a/installation/manual.rst
+++ b/installation/manual.rst
@@ -106,7 +106,7 @@ And create a new virtual environment called :code:`mad_env` in your home directo
 
 Whenever you see :code:`python3` or :code:`pip3` in the documentation, use :code:`~/mad_env/bin/python3` and :code:`~/mad_env/bin/pip3` instead. And, of course, use a different environment location for different python tools.
 
-You can activate the virtual environment via `source ~/mad_env/bin/activate`. This makes sure you can simply call `python3` or `pip3` wherever you are and it will perform all commands with the Python version and the dependencies form your virtualenvironment. Have a look at `this <https://docs.python.org/3/tutorial/venv.html>`_ or `this <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/>`_ link for more information.
+You can activate the virtual environment via :code:`source ~/mad_env/bin/activate`. This makes sure you can simply call `python3` or `pip3` wherever you are and it will perform all commands with the Python version and the dependencies form your virtualenvironment. Have a look at `this <https://docs.python.org/3/tutorial/venv.html>`_ or `this <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/>`_ link for more information.
 
 .. _sec_manual_mad:
 


### PR DESCRIPTION
In the manual installation instructions, a few text blocks were not correctly displayed as code.